### PR TITLE
Reinitialize session in case it does not exist

### DIFF
--- a/lib/kitchen/transport/rsync.rb
+++ b/lib/kitchen/transport/rsync.rb
@@ -44,6 +44,7 @@ module Kitchen
             return super
           end
 
+          @session ||= session
           locals = Array(locals)
           # We only try to sync folders for now and ignore the cache folder
           # because we don't want to --delete that.


### PR DESCRIPTION
Otherwise the second 'verify' invocation with rsync transport will fail
with [undefined method `options' for nil:NilClass] due to nonexistent
session
