### PR TITLE
Fix gh-33 quiet the output of sftp transfer time

### DIFF
--- a/lib/kitchen/transport/sftp.rb
+++ b/lib/kitchen/transport/sftp.rb
@@ -100,7 +100,7 @@ module Kitchen
             time = Benchmark.realtime do
               sftp_upload!(local, full_remote, options)
             end
-            logger.info("[SFTP] Time taken to upload #{local} to #{self}:#{full_remote}: %.2f sec" % time)
+            logger.debug("[SFTP] Time taken to upload #{local} to #{full_remote}: %.2f sec" % time)
           end
         end
 


### PR DESCRIPTION
* Previously the output of the travel time and the entire object
  was dumped to the console causing massive amounts of output.

* This fixes that by removing the self object from being dumped
   and also setting the log level to debug instead of info.