### PR TITLE
Fix for ruby 3.0+

### DIFF
--- a/lib/kitchen/transport/sftp.rb
+++ b/lib/kitchen/transport/sftp.rb
@@ -98,7 +98,7 @@ module Kitchen
             }
             recursive = File.directory?(local)
             time = Benchmark.realtime do
-              sftp_upload!(local, full_remote, options)
+              sftp_upload!(local, full_remote, **options)
             end
             logger.info("[SFTP] Time taken to upload #{local} to #{self}:#{full_remote}: %.2f sec" % time)
           end


### PR DESCRIPTION
Ruby 3.0 has deprecated passing an hash as last parameter that is expanded by the receiving function as if it were multiple parameters.

See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

So with a function definition as in https://github.com/coderanger/kitchen-sync/blob/master/lib/kitchen/transport/sftp.rb#L109 the call in https://github.com/coderanger/kitchen-sync/blob/master/lib/kitchen/transport/sftp.rb#L101 is now incompatible with ruby 3.0+

Kitchen is then unable to converge with the following traceback (with `-l debug`):
```
D      ---Nested Exception---
D      Class: Kitchen::ActionFailed
D      Message: Failed to complete #converge action: [wrong number of arguments (given 3, expected 2)]
D      ----------------------
D      ------Backtrace-------
D      /var/lib/gems/3.0.0/gems/kitchen-sync-2.2.1/lib/kitchen/transport/sftp.rb:109:in `sftp_upload!'
D      /var/lib/gems/3.0.0/gems/kitchen-sync-2.2.1/lib/kitchen/transport/sftp.rb:101:in `block (2 levels) in upload'
D      /usr/lib/ruby/3.0.0/benchmark.rb:308:in `realtime'
D      /var/lib/gems/3.0.0/gems/kitchen-sync-2.2.1/lib/kitchen/transport/sftp.rb:100:in `block in upload'
D      /var/lib/gems/3.0.0/gems/kitchen-sync-2.2.1/lib/kitchen/transport/sftp.rb:93:in `each'
D      /var/lib/gems/3.0.0/gems/kitchen-sync-2.2.1/lib/kitchen/transport/sftp.rb:93:in `upload'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/provisioner/base.rb:82:in `block in call'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/transport/ssh.rb:570:in `reuse_connection'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/transport/ssh.rb:97:in `connection'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/provisioner/base.rb:74:in `call'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:419:in `block in converge_action'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:563:in `synchronize_or_call'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:524:in `block in action'
D      /usr/lib/ruby/3.0.0/benchmark.rb:293:in `measure'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:523:in `action'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:414:in `converge_action'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:392:in `block (2 levels) in transition_to'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/lifecycle_hooks.rb:47:in `run_with_hooks'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:391:in `block in transition_to'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:390:in `each'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:390:in `transition_to'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/instance.rb:139:in `converge'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/command.rb:195:in `public_send'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/command.rb:195:in `run_action_in_thread'
D      /var/lib/gems/3.0.0/gems/test-kitchen-3.3.2/lib/kitchen/command.rb:166:in `block (2 levels) in run_action'
D      ----End Backtrace-----
```

This PR fixes that behaviour by flattening (passing by reference) the content of the hash as arguments to `sftp_upload!`